### PR TITLE
Fix cursor undefined error

### DIFF
--- a/dump-messages.js
+++ b/dump-messages.js
@@ -393,7 +393,7 @@
           return originalDecrypt.call(this, algorithm, key, data);
         };  
       } else {
-        cursor.continue();
+        event.target.result.continue()
       }
     };
   }


### PR DESCRIPTION
In some cases, Line 396 is triggered, where `cursor` is not defined. This crashes the script.
This is a minor fix, which resolves the above case.